### PR TITLE
Next draft

### DIFF
--- a/srfi-147.html
+++ b/srfi-147.html
@@ -112,11 +112,14 @@ This SRFI extends 7.1.5 of the R7RS as follows:
   transformer is given by a transformer spec that is a macro use, the
   keyword is bound to the macro transformer given by the transformer
   spec that results from transcribing the macro use.  It is an error
-  if the macro use does not expand into a transformer spec (but see below).  In case
-  of transformer specs that appear in the bindings of
-  the <code>let-syntax</code> and <code>letrec-syntax</code> binding
+  if the macro use does not expand into a transformer spec (but see
+  below).  In case of transformer specs that appear in the bindings of
+  the <code>let-syntax</code> binding construct, the expansion of the
+  transformer spec takes place in the (outer) scope of the binding
+  construct.  In case of transformer specs that appear in the bindings of
+  the <code>letrec-syntax</code> binding
   constructs, the expansion of the transformer spec takes place in the
-  (outer) scope of the binding construct.
+  scope of the body of the binding construct.
 </p>
 
 <p>

--- a/srfi-147.html
+++ b/srfi-147.html
@@ -122,7 +122,7 @@ This SRFI extends 7.1.5 of the R7RS as follows:
   construct.  In case of transformer specs that appear in the bindings of
   the <code>letrec-syntax</code> binding
   constructs, the expansion of the transformer spec takes place in the
-  scope of the body of the binding construct.
+  scope of the bindings of the binding construct.
 </p>
 
 <p>

--- a/srfi-147.html
+++ b/srfi-147.html
@@ -28,10 +28,12 @@ Marc Nieper-Wi&szlig;kirchen
 <p>
 Each syntax definition assigns a macro transformer to a keyword.  The
 macro transformer is specified by a transformer spec, which is either
-an instance of <code>syntax-rules</code> or a use of a macro that eventually
-expands into an instance of <code>syntax-rules</code>.  In the
-latter case, the keyword of macro use is called a <em>custom macro
-transformer</em>.
+an instance of <code>syntax-rules</code>, an existing syntactic keyword
+(including macro keywords and the syntactic keywords that introduce the core forms,
+like <code>lambda</code>, <code>if</code>, or <code>define</code>), or
+a use of a macro that eventually expands into an instance
+of <code>syntax-rules</code>.  In the latter case, the keyword of
+macro use is called a <em>custom macro transformer</em>.
 </p>
 
 <h1>Issues</h1>
@@ -104,7 +106,8 @@ This SRFI extends 7.1.5 of the R7RS as follows:
 
 <pre>
   &lt;transformer spec&gt; 
-    -&gt; &lt;macro use&gt;
+   -&gt; &lt;keyword&gt;
+   -&gt; &lt;macro use&gt;
 </pre>
 
 <p>
@@ -120,6 +123,17 @@ This SRFI extends 7.1.5 of the R7RS as follows:
   the <code>letrec-syntax</code> binding
   constructs, the expansion of the transformer spec takes place in the
   scope of the body of the binding construct.
+</p>
+
+<p>
+  If the transformer spec is a <em>keyword</em>, the keyword bound to
+  the transformer spec essentially becomes an alias to the syntactic
+  keyword <em>keyword</em>.  (<em>Keyword</em> may also be one of the
+  core syntactic keywords
+  like <code>lambda</code>, <code>if</code>, <code>define</code>.)
+  The same holds if the transformer spec is a macro use that
+  eventually expands into a (possibly empty) sequence of multiple definitions followed by
+  the <em>keyword</em> (possibly bound by the introduced definitions).
 </p>
 
 <p>

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -32,7 +32,10 @@
 	    ...
 	    (expand-transformer (k ...) transformer-spec)))   
     ((expand-transformer (k ...) (keyword . args))
-     (keyword (:continuation expand-transformer (k ...)) . args))))
+     (keyword (:continuation expand-transformer (k ...)) . args))
+    ((expand-transformer (k ...) keyword)
+     (k ... (scheme-syntax-rules ()
+	      ((_ . args) (keyword . args)))))))
 
 (scheme-define-syntax define-syntax
   (scheme-syntax-rules ()

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -80,7 +80,7 @@
 (scheme-define-syntax letrec-syntax-aux
   (scheme-syntax-rules ()
     ((letrec-syntax-aux (keyword ...) () (transformer-spec ...) body*)
-     (begin
+     (let ()
        (define-syntax keyword transformer-spec)
        ...
        (let () . body*)))

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -80,7 +80,10 @@
 (scheme-define-syntax letrec-syntax-aux
   (scheme-syntax-rules ()
     ((letrec-syntax-aux (keyword ...) () (transformer-spec ...) body*)
-     (scheme-letrec-syntax ((keyword transformer-spec) ...) . body*))
+     (begin
+       (define-syntax keyword transformer-spec)
+       ...
+       (let () . body*)))
     ((letrec-syntax-aux keyword*
 			(transformer-spec1 transformer-spec2 ...)
 			transformer-spec*

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -83,7 +83,7 @@
 (scheme-define-syntax letrec-syntax-aux
   (scheme-syntax-rules ()
     ((letrec-syntax-aux (keyword ...) () (transformer-spec ...) body*)
-     (let ()
+     (begin
        (define-syntax keyword transformer-spec)
        ...
        (let () . body*)))

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -121,7 +121,6 @@
 
     ((syntax-rules-aux "state1" k* ::: l*
        (((_ . pattern) template) . rule1*) (rule2 ...) rule3*)
-
      (syntax-rules-aux "state1" k* ::: l* rule1*
        (rule2
 	...

--- a/srfi/147/test.sld
+++ b/srfi/147/test.sld
@@ -121,6 +121,11 @@
 
 	(test-equal '(a b c) (foo a b c)))
 
+      (test-group "Aliases for keywords"
+	(define-syntax λ lambda)
+	(define foo (λ () 'baz))
+	(test-equal 'baz (foo)))
+
       (test-group "Example from specification"
 	(define-syntax syntax-rules*
 	  (syntax-rules ()

--- a/srfi/147/test.sld
+++ b/srfi/147/test.sld
@@ -41,7 +41,18 @@
 			     (syntax-rules ()
 			       ((foo)
 				42))))
-			 (foo))))
+			 (foo)))
+
+	(test-equal 42 (letrec-syntax
+			   ((foo
+			     (syntax-rules ()
+			       ((foo)
+				42)))
+			    (bar
+			     (syntax-rules ()
+			       ((bar)
+				(foo)))))
+			 (bar))))
 
       (test-group "Custom macro transformers"
 	(define-syntax simple-syntax-rules
@@ -109,7 +120,7 @@
   	    ((foo a :::) (list 'a :::))))
 
 	(test-equal '(a b c) (foo a b c)))
-      
+
       (test-group "Example from specification"
 	(define-syntax syntax-rules*
 	  (syntax-rules ()

--- a/srfi/147/test.sld
+++ b/srfi/147/test.sld
@@ -102,7 +102,7 @@
 	    ((simple-syntax-rules . rules)
 	     (syntax-rules () . rules))))
 
-	(test-equal 'foo (letrec-syntax
+	(test-equal 'foo (let-syntax
 			     ((simple-syntax-rules
 			       (simple-syntax-rules ((_) 'foo))))
 			   (simple-syntax-rules))))


### PR DESCRIPTION
- improved scoping rules in case of the letrec-syntax binding construct
- keywords can now also be bound to existing keywords, effectively allowing aliases
