### PR TITLE
Clarify use of begin in transformer specs

### DIFF
--- a/srfi-147.html
+++ b/srfi-147.html
@@ -121,6 +121,7 @@ This SRFI extends 7.1.5 of the R7RS as follows:
   &lt;transformer spec&gt; 
    -&gt; &lt;keyword&gt;
    -&gt; &lt;macro use&gt;
+   -&gt; (begin &lt;definition&gt;&hellip; &lt;transformer spec&gt;)
 </pre>
 
 <p>
@@ -152,8 +153,14 @@ This SRFI extends 7.1.5 of the R7RS as follows:
 <p>
   In order to facilitate writing sophisticated custom macro
   transformers, it is allowed that a transformer spec expands into a
-  sequence of multiple definitions eventually followed by a
-  transformer spec (whose expansion may make use of the introduced definitions).
+  sequence introduced by the keyword <code>begin</code> of multiple
+  definitions eventually followed by a transformer spec (whose
+  expansion may make use of the introduced definitions).
+</p>
+
+<p><i>Note: This form of <code>begin</code> is a fourth form
+    of <code>begin</code> different from the forms described in sections
+    4.2.3 and sections 5.6.1 of the R7RS.</i>
 </p>
 
 <h1>Implementation</h1>


### PR DESCRIPTION
Please incorporate this pull request into an erratum for the spec as per recent discussion on the mailing list.