### PR TITLE
Fixed sample implementation

### DIFF
--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -25,24 +25,24 @@
 
 (scheme-define-syntax expand-transformer
   (scheme-syntax-rules (scheme-syntax-rules syntax-error begin)
-    ((expand-transformer :c (k ...) (scheme-syntax-rules . args))
+    ((expand-transformer (k ...) (scheme-syntax-rules . args))
      (k ... (scheme-syntax-rules . args)))
-    ((expand-transformer :c (k ...) (syntax-error . args))
+    ((expand-transformer (k ...) (syntax-error . args))
      (syntax-error . args))
-    ((expand-transformer c: (k ...) (begin definition ... transformer-spec))
+    ((expand-transformer (k ...) (begin definition ... transformer-spec))
      (begin definition
 	    ...
-	    (expand-transformer c: (k ...) transformer-spec)))   
-    ((expand-transformer c: (k ...) (keyword . args))
+	    (expand-transformer (k ...) transformer-spec)))   
+    ((expand-transformer (k ...) (keyword . args))
      (keyword (:c expand-transformer (k ...)) . args))
-    ((expand-transformer c: (k ...) keyword)
+    ((expand-transformer (k ...) keyword)
      (k ... (scheme-syntax-rules ()
 	      ((_ . args) (keyword . args)))))))
 
 (scheme-define-syntax define-syntax
   (scheme-syntax-rules ()
     ((define-syntax name transformer-spec)
-     (expand-transformer :c (scheme-define-syntax name) transformer-spec))
+     (expand-transformer (scheme-define-syntax name) transformer-spec))
     ((define-syntax . _)
      (syntax-error "invalid define-syntax syntax"))))
 
@@ -59,7 +59,7 @@
     ((let-syntax-aux (keyword ...) () (transformer-spec ...) body*)
      (scheme-let-syntax ((keyword transformer-spec) ...) . body*))
     ((let-syntax-aux keyword* (transformer-spec1 transformer-spec2 ...) transformer-spec* body*)
-     (expand-transformer :c (let-syntax-aux keyword*
+     (expand-transformer (let-syntax-aux keyword*
 					    (transformer-spec2 ...)
 					    transformer-spec*
 					    body*)
@@ -93,7 +93,7 @@
 			(transformer-spec1 transformer-spec2 ...)
 			transformer-spec*
 			body*)
-     (expand-transformer c: (letrec-syntax-aux keyword*
+     (expand-transformer (letrec-syntax-aux keyword*
 					       (transformer-spec2 ...)
 					       transformer-spec*
 					       body*)
@@ -111,25 +111,25 @@
 (scheme-define-syntax syntax-rules
   (scheme-syntax-rules (:c)
     ((syntax-rules (:c k ...) . args)
-     (syntax-rules-aux "state0" (k ...) . args))
+     (syntax-rules-aux "state0" :c (k ...) . args))
     ((syntax-rules . _)
      (syntax-error "invalid syntax-rules syntax"))))
 
 (scheme-define-syntax syntax-rules-aux
   (scheme-syntax-rules ()
-    ((syntax-rules-aux "state0" k* (literal* ...) . rule*)
-     (syntax-rules-aux "state1" k* (... ...) ((literal* ... :c)) rule* () rule*))
+    ((syntax-rules-aux "state0" :c k* (literal* ...) . rule*)
+     (syntax-rules-aux "state1" :c k* (... ...) ((literal* ... :c)) rule* () rule*))
 
-    ((syntax-rules-aux "state0" k* ellipsis (literal* ...) . rule*)
-     (syntax-rules-aux "state1" k* ellipsis (ellipsis (literal* ... :c))
+    ((syntax-rules-aux "state0" :c k* ellipsis (literal* ...) . rule*)
+     (syntax-rules-aux "state1" :c k* ellipsis (ellipsis (literal* ... :c))
        rule* () rule*))
    
-    ((syntax-rules-aux "state1" (k ...) e (l ...) () (rule1* ...) rule2*)
+    ((syntax-rules-aux "state1" :c (k ...) e (l ...) () (rule1* ...) rule2*)
      (k ... (scheme-syntax-rules l ... rule1* ... . rule2*)))
 
-    ((syntax-rules-aux "state1" k* ::: l*
+    ((syntax-rules-aux "state1" :c k* ::: l*
        (((_ . pattern) template) . rule1*) (rule2 ...) rule3*)
-     (syntax-rules-aux "state1" k* ::: l* rule1*
+     (syntax-rules-aux "state1" :c k* ::: l* rule1*
        (rule2
 	...
 	((_ (:c c :::) . pattern)

--- a/srfi/147.scm
+++ b/srfi/147.scm
@@ -20,29 +20,29 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(scheme-define-syntax :continuation
+(scheme-define-syntax :c
   (scheme-syntax-rules ()))
 
 (scheme-define-syntax expand-transformer
   (scheme-syntax-rules (scheme-syntax-rules syntax-error begin)
-    ((expand-transformer (k ...) (scheme-syntax-rules . args))
+    ((expand-transformer :c (k ...) (scheme-syntax-rules . args))
      (k ... (scheme-syntax-rules . args)))
-    ((expand-transformer (k ...) (syntax-error . args))
+    ((expand-transformer :c (k ...) (syntax-error . args))
      (syntax-error . args))
-    ((expand-transformer (k ...) (begin definition ... transformer-spec))
+    ((expand-transformer c: (k ...) (begin definition ... transformer-spec))
      (begin definition
 	    ...
-	    (expand-transformer (k ...) transformer-spec)))   
-    ((expand-transformer (k ...) (keyword . args))
-     (keyword (:continuation expand-transformer (k ...)) . args))
-    ((expand-transformer (k ...) keyword)
+	    (expand-transformer c: (k ...) transformer-spec)))   
+    ((expand-transformer c: (k ...) (keyword . args))
+     (keyword (:c expand-transformer (k ...)) . args))
+    ((expand-transformer c: (k ...) keyword)
      (k ... (scheme-syntax-rules ()
 	      ((_ . args) (keyword . args)))))))
 
 (scheme-define-syntax define-syntax
   (scheme-syntax-rules ()
     ((define-syntax name transformer-spec)
-     (expand-transformer (scheme-define-syntax name) transformer-spec))
+     (expand-transformer :c (scheme-define-syntax name) transformer-spec))
     ((define-syntax . _)
      (syntax-error "invalid define-syntax syntax"))))
 
@@ -59,10 +59,10 @@
     ((let-syntax-aux (keyword ...) () (transformer-spec ...) body*)
      (scheme-let-syntax ((keyword transformer-spec) ...) . body*))
     ((let-syntax-aux keyword* (transformer-spec1 transformer-spec2 ...) transformer-spec* body*)
-     (expand-transformer (let-syntax-aux keyword*
-					 (transformer-spec2 ...)
-					 transformer-spec*
-					 body*)
+     (expand-transformer :c (let-syntax-aux keyword*
+					    (transformer-spec2 ...)
+					    transformer-spec*
+					    body*)
 			 transformer-spec1))
     ((let-syntax-aux keyword*
 		     (transformer-spec2 ...)
@@ -93,10 +93,10 @@
 			(transformer-spec1 transformer-spec2 ...)
 			transformer-spec*
 			body*)
-     (expand-transformer (letrec-syntax-aux keyword*
-					    (transformer-spec2 ...)
-					    transformer-spec*
-					    body*)
+     (expand-transformer c: (letrec-syntax-aux keyword*
+					       (transformer-spec2 ...)
+					       transformer-spec*
+					       body*)
 			 transformer-spec1))
     ((letrec-syntax-aux keyword*
 			(transformer-spec2 ...)
@@ -109,8 +109,8 @@
 			body*))))
 
 (scheme-define-syntax syntax-rules
-  (scheme-syntax-rules (:continuation)
-    ((syntax-rules (:continuation k ...) . args)
+  (scheme-syntax-rules (:c)
+    ((syntax-rules (:c k ...) . args)
      (syntax-rules-aux "state0" (k ...) . args))
     ((syntax-rules . _)
      (syntax-error "invalid syntax-rules syntax"))))
@@ -118,10 +118,10 @@
 (scheme-define-syntax syntax-rules-aux
   (scheme-syntax-rules ()
     ((syntax-rules-aux "state0" k* (literal* ...) . rule*)
-     (syntax-rules-aux "state1" k* (... ...) ((literal* ... :continuation)) rule* () rule*))
+     (syntax-rules-aux "state1" k* (... ...) ((literal* ... :c)) rule* () rule*))
 
     ((syntax-rules-aux "state0" k* ellipsis (literal* ...) . rule*)
-     (syntax-rules-aux "state1" k* ellipsis (ellipsis (literal* ... :continuation))
+     (syntax-rules-aux "state1" k* ellipsis (ellipsis (literal* ... :c))
        rule* () rule*))
    
     ((syntax-rules-aux "state1" (k ...) e (l ...) () (rule1* ...) rule2*)
@@ -132,7 +132,7 @@
      (syntax-rules-aux "state1" k* ::: l* rule1*
        (rule2
 	...
-	((_ (:continuation c :::) . pattern)
+	((_ (:c c :::) . pattern)
 	 (c ::: template)))
        rule3*))
     ((syntax-rules-aux . _)

--- a/srfi/147.sld
+++ b/srfi/147.sld
@@ -25,9 +25,26 @@
 	  let-syntax
 	  letrec-syntax
 	  syntax-rules)
-  (import (rename (scheme base)
+  (import (rename (except (scheme base) let-syntax letrec-syntax)
 		  (syntax-rules scheme-syntax-rules)
-		  (define-syntax scheme-define-syntax)
-		  (let-syntax scheme-let-syntax)
-		  (letrec-syntax scheme-letrec-syntax)))
+		  (define-syntax scheme-define-syntax)))
+  (cond-expand
+   ;; Larceny exports let-syntax and letrec-syntax with R6RS semantcs,
+   ;; which is incompatible to the R7RS semantics.
+   (larceny
+    (import (rename (only (scheme base) let-syntax letrec-syntax)
+		    (let-syntax let-syntax/splicing)
+		    (letrec-syntax letrec-syntax/splicing)))
+    (begin
+      (scheme-define-syntax scheme-let-syntax
+	(scheme-syntax-rules ()
+	  ((scheme-let-syntax bindings . body)
+	   (let () (let-syntax/splicing bindings . body)))))
+      
+      (scheme-define-syntax scheme-letrec-syntax
+	(scheme-syntax-rules ()
+	  ((scheme-letrec-syntax bindings . body)
+	   (let () (letrec-syntax/splicing bindings . body)))))))
+   (else
+    (import (prefix (only (scheme base) let-syntax letrec-syntax) scheme-))))
   (include "147.scm"))


### PR DESCRIPTION
The sample implementation is now compatible with Schemes where literal identifiers in syntax-rules are lexically scoped (that is, an identifier pattern is a literal identifier if and only if it is bound-identifier=? to a literal appearing in the list of literals).
