### PR TITLE
Add Chibi-specific implementation for er-macro-transformer

### DIFF
--- a/srfi/147/er-macro-transformer.scm
+++ b/srfi/147/er-macro-transformer.scm
@@ -20,9 +20,16 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 147)
-  (export define-syntax
-	  let-syntax
-	  letrec-syntax
-	  syntax-rules)
-  (import (srfi 147 implementation)))
+(scheme-define-syntax er-macro-transformer
+  (scheme-syntax-rules (:c)
+    ((er-macro-transformer (:c k ...) transformer)
+     (k ... 
+	(scheme-er-macro-transformer
+	 (lambda (expr rename compare)
+	   (if (and (pair? (cdr expr))
+		    (pair? (cadr expr))
+		    (compare ':c (caadr expr)))
+	       `(,@(cdadr expr) ,(transformer (cons (car expr) (cddr expr)) rename compare))
+	       (transformer expr rename compare))))))
+    ((er-macro-transformer . _)
+     (syntax-error "invalid er-macro-transformer syntax"))))

--- a/srfi/147/er-macro-transformer.sld
+++ b/srfi/147/er-macro-transformer.sld
@@ -20,9 +20,6 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(define-library (srfi 147)
-  (export define-syntax
-	  let-syntax
-	  letrec-syntax
-	  syntax-rules)
+(define-library (srfi 147 er-macro-transformer)
+  (export er-macro-transformer)
   (import (srfi 147 implementation)))

--- a/srfi/147/er-macro-transformer/test.sld
+++ b/srfi/147/er-macro-transformer/test.sld
@@ -1,0 +1,94 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2016).  All Rights Reserved. 
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(define-library (srfi 147 er-macro-transformer test)
+  (export run-tests)
+  (include-library-declarations "../../../custom-macro-transformers.scm")
+  (import (srfi 147 er-macro-transformer))
+  (import (srfi 64))
+  (begin
+    (define (run-tests)
+      (test-begin "SRFI 147: er-macro-transformer")
+
+      (test-group "R7RS macros"
+
+        (define-syntax foo
+	  (er-macro-transformer
+	   (lambda (expr rename compare)
+	     42)))
+
+	(test-equal 42 (foo))
+
+	(test-equal 42 (let-syntax
+			   ((foo
+			     (er-macro-transformer
+			      (lambda (expr rename compare)
+				42))))
+			 (foo)))
+
+	(test-equal 42 (letrec-syntax
+			   ((foo
+			     (er-macro-transformer
+			      (lambda (expr rename compare)
+				42)))
+			    (bar
+			     (er-macro-transformer
+			      (lambda (expr rename compare)
+				`(,(rename 'foo))))))
+			 (bar))))
+
+      (test-group "Custom macro transformers"
+
+	(define-syntax unhygienic-transformer
+	  (syntax-rules ()
+	    ((unhygienic-transformer transformer)
+	     (er-macro-transformer
+	      (lambda (expr rename compare)
+		(transformer expr))))))
+
+	(define-syntax bar-transformer
+	  (unhygienic-transformer
+	   (lambda (expr)
+	     '(unhygienic-transformer
+	       (lambda (expr)
+		 ''bar)))))
+	
+	(define-syntax foo
+	  (unhygienic-transformer
+	   (lambda (expr)
+	     42)))
+
+	(define-syntax bar
+	  (bar-transformer))
+	
+	(test-equal 42 (foo))
+    
+	(test-equal 42 (let-syntax
+			   ((foo
+			     (unhygienic-transformer
+			       (lambda (expr)
+				 42))))
+			 (foo)))
+
+	(test-equal 'bar (bar 42)))
+
+      (test-end))))

--- a/srfi/147/implementation.scm
+++ b/srfi/147/implementation.scm
@@ -24,9 +24,11 @@
   (scheme-syntax-rules ()))
 
 (scheme-define-syntax expand-transformer
-  (scheme-syntax-rules (scheme-syntax-rules syntax-error begin)
+  (scheme-syntax-rules (scheme-syntax-rules scheme-er-macro-transformer syntax-error begin)
     ((expand-transformer (k ...) (scheme-syntax-rules . args))
      (k ... (scheme-syntax-rules . args)))
+    ((expand-transformer (k ...) (scheme-er-macro-transformer . args))
+     (k ... (scheme-er-macro-transformer . args)))
     ((expand-transformer (k ...) (syntax-error . args))
      (syntax-error . args))
     ((expand-transformer (k ...) (begin definition ... transformer-spec))

--- a/srfi/147/implementation.sld
+++ b/srfi/147/implementation.sld
@@ -1,0 +1,61 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2016).  All Rights Reserved. 
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(define-library (srfi 147 implementation)
+  (export define-syntax
+	  let-syntax
+	  letrec-syntax
+	  syntax-rules)
+  (import (rename (except (scheme base) let-syntax letrec-syntax)
+		  (syntax-rules scheme-syntax-rules)
+		  (define-syntax scheme-define-syntax)))
+  (include "implementation.scm")
+  (cond-expand
+
+    (chibi
+     (export er-macro-transformer)
+     (import (rename (only (chibi) er-macro-transformer display)
+		     (er-macro-transformer scheme-er-macro-transformer))
+	     (scheme cxr))
+     (import (prefix (only (scheme base) let-syntax letrec-syntax) scheme-))
+     (include "er-macro-transformer.scm"))
+
+    ;; Larceny exports let-syntax and letrec-syntax with R6RS semantcs,
+    ;; which is incompatible to the R7RS semantics.
+    (larceny
+     (import (rename (only (scheme base) let-syntax letrec-syntax)
+		     (let-syntax let-syntax/splicing)
+		     (letrec-syntax letrec-syntax/splicing)))
+     (begin
+       (scheme-define-syntax scheme-let-syntax
+	 (scheme-syntax-rules ()
+	   ((scheme-let-syntax bindings . body)
+	    (let () (let-syntax/splicing bindings . body)))))
+       
+       (scheme-define-syntax scheme-letrec-syntax
+	 (scheme-syntax-rules ()
+	   ((scheme-letrec-syntax bindings . body)
+	    (let () (letrec-syntax/splicing bindings . body)))))))
+
+    (else
+     (import (rename (scheme base) (syntax-rules scheme-er-macro-transformer)))
+     (import (prefix (only (scheme base) let-syntax letrec-syntax) scheme-)))))

--- a/tests.scm
+++ b/tests.scm
@@ -21,5 +21,9 @@
 ;; SOFTWARE.
 
 (import (rename (srfi 147 test) (run-tests run-srfi-147-tests)))
+(import (rename (srfi 147 er-macro-transformer test)
+		(run-tests run-srfi-147-er-macro-transformer-tests)))
 
 (run-srfi-147-tests)
+(run-srfi-147-er-macro-transformer-tests)
+


### PR DESCRIPTION
This is a feature enhancement of the sample implementation of SRFI 147. That document says: 

> A Scheme system supporting this SRFI should apply the requirements of this SRFI with respect to syntax-rules mutatis mutandis to all other natively provided macro transformers, e.g. sc-macro-transformer or syntax-case.

Code has been added to the sample implementation that demonstrates how this can be implemented for Chibi's er-macro-transformer. A SRFI 147-compatible `er-macro-transformer` can be imported from `(srfi 147 er-macro-transformer)`. The code should be easily adaptable to other implementations.

